### PR TITLE
Remove lot-level 3D models and restrict ship viewer

### DIFF
--- a/patches/cephes+1.2.0.patch
+++ b/patches/cephes+1.2.0.patch
@@ -2,10 +2,11 @@ diff --git a/node_modules/cephes/cephes-wrapper.js b/node_modules/cephes/cephes-
 index a492838..0c793f7 100644
 --- a/node_modules/cephes/cephes-wrapper.js
 +++ b/node_modules/cephes/cephes-wrapper.js
-@@ -1,5 +1,4 @@
+@@ -1,5 +1,5 @@
 -
 -const fs = require('fs');
-+self.Buffer = self.Buffer || require('buffer').Buffer;
++const _root = (typeof self !== 'undefined') ? self : globalThis;
++_root.Buffer = _root.Buffer || require('buffer').Buffer;
  
  const TOTAL_STACK = 1024 * 1024; // 1MB
  const TOTAL_MEMORY = 2 * 1024 * 1024; // 1MB

--- a/src/components/ShipLink.js
+++ b/src/components/ShipLink.js
@@ -29,6 +29,8 @@ export const useShipLink = ({ crewId, shipId, zoomToShip }) => {
     if (!ship) return;
 
     let delayToZoomScene = 500;
+    const isOnLot = !!ship?._location?.lotId;
+    const menuToOpen = (isOnLot && zoomToShip && zoomToShip !== true) ? 'LOT_INFORMATION' : zoomToShip;
 
     // if ship is in_flight, zoom "out", show zoomScene of ship
     if (ship.Ship?.transitDeparture > 0) {
@@ -39,7 +41,7 @@ export const useShipLink = ({ crewId, shipId, zoomToShip }) => {
       }
 
     // if ship is in_port / on_surface, zoom to lot, show zoomScene of ship
-    } else if (!!ship?._location.lotId) {
+    } else if (isOnLot) {
       zoomToLot();
 
     // if ship is landing/launching/in_orbit, zoom to asteroid, show zoomScene of ship
@@ -50,16 +52,20 @@ export const useShipLink = ({ crewId, shipId, zoomToShip }) => {
 
     // show zoomScene of ship
     const shipShipId = ship.label === Entity.IDS.SHIP ? ship.id : null;
-    if (zoomToShip && !(currentZoomScene?.type === 'SHIP' && currentZoomScene?.shipId === shipShipId)) {
+    if (!isOnLot && zoomToShip && !(currentZoomScene?.type === 'SHIP' && currentZoomScene?.shipId === shipShipId)) {
       setTimeout(() => {
         dispatchZoomScene(zoomToShip ? { type: 'SHIP', shipId: shipShipId } : null);
 
         // if this is not just a boolean, it is assumed to be a hudmenu to open upon arrival
-        if (zoomToShip && zoomToShip !== true) {
+        if (menuToOpen && menuToOpen !== true) {
           setTimeout(() => {
-            dispatchHudMenuOpened(zoomToShip);
+            dispatchHudMenuOpened(menuToOpen);
           }, 0);
         }
+      }, delayToZoomScene);
+    } else if (isOnLot && menuToOpen && menuToOpen !== true) {
+      setTimeout(() => {
+        dispatchHudMenuOpened(menuToOpen);
       }, delayToZoomScene);
     }
   }, [currentZoomScene, ship, zoomToAsteroid, zoomToLot, zoomToShip, dispatchZoomScene, dispatchHudMenuOpened]);

--- a/src/game/Interface.js
+++ b/src/game/Interface.js
@@ -21,7 +21,6 @@ import AsteroidDetails from './interface/details/AsteroidDetails';
 // import CrewAssignmentComplete from './interface/details/crewAssignments/Complete';
 import CrewmateDetails from './interface/details/CrewmateDetails';
 import Marketplace from './interface/details/Marketplace';
-import LotViewer from './interface/modelViewer/LotViewer';
 import ShipViewer from './interface/modelViewer/ShipViewer';
 import LinkedViewer from './interface/modelViewer/LinkedViewer';
 import DevToolsViewer from './interface/modelViewer/DevToolsViewer';
@@ -184,7 +183,6 @@ const Interface = () => {
             </Route>
           </Switch>
 
-          <LotViewer />
           <ShipViewer />
           <HUD />
           <MainMenu />

--- a/src/game/interface/hud/HudMenu.js
+++ b/src/game/interface/hud/HudMenu.js
@@ -325,7 +325,7 @@ const HudMenu = () => {
       const category = openHudMenu.split('_').shift();
       if (category === 'BELT' && zoomStatus !== 'out') dispatchHudMenuOpened();
       if (category === 'ASTEROID' && !(zoomStatus === 'in' && !zoomScene)) dispatchHudMenuOpened();
-      if (category === 'LOT' && !(zoomStatus === 'in' && zoomScene?.type === 'LOT')) dispatchHudMenuOpened();
+      if (category === 'LOT' && !(zoomStatus === 'in' && lotId)) dispatchHudMenuOpened();
       if (category === 'SHIP' && !(zoomStatus === 'in' && zoomScene?.type === 'SHIP')) dispatchHudMenuOpened();
     }
   }, [dispatchHudMenuOpened, zoomScene, zoomStatus]);
@@ -362,7 +362,7 @@ const HudMenu = () => {
     if (!launcherPage) {
       let scope = 'belt'; // belt, asteroid, lot, ship
       if (zoomStatus === 'in') scope = 'asteroid';
-      if (zoomScene?.type === 'LOT') scope = 'lot';
+      if (lotId) scope = 'lot';
       if (zoomScene?.type === 'SHIP') scope = 'ship'; // TODO: probably only if ship is in flight should we change scope
 
       let focus = ''; // asteroid, lot, ship

--- a/src/game/interface/hud/InfoPane.js
+++ b/src/game/interface/hud/InfoPane.js
@@ -343,7 +343,7 @@ const InfoPane = () => {
 
   const dispatchOriginSelected = useStore(s => s.dispatchOriginSelected);
   const dispatchLotSelected = useStore(s => s.dispatchLotSelected);
-  const dispatchZoomScene = useStore(s => s.dispatchZoomScene);
+  const dispatchHudMenuOpened = useStore(s => s.dispatchHudMenuOpened);
   const updateZoomStatus = useStore(s => s.dispatchZoomStatusChanged);
   const playSound = useStore(s => s.dispatchEffectStartRequested);
   const stopSound = useStore(s => s.dispatchEffectStopRequested);
@@ -366,7 +366,7 @@ const InfoPane = () => {
   const onClickPane = useCallback(() => {
     // open lot
     if (asteroidId && lotId && zoomStatus === 'in') {
-      dispatchZoomScene({ type: 'LOT' });
+      dispatchHudMenuOpened('LOT_INFORMATION');
 
     // open asteroid details
     } else if (asteroidId && zoomStatus === 'in') {
@@ -376,7 +376,7 @@ const InfoPane = () => {
     } else if (asteroidId && zoomStatus === 'out') {
       updateZoomStatus('zooming-in');
     }
-  }, [asteroidId, lotId, zoomStatus, lot?.building]);
+  }, [asteroidId, lotId, zoomStatus, lot?.building, dispatchHudMenuOpened]);
 
   const onClosePane = useCallback((e) => {
     e.stopPropagation();
@@ -505,7 +505,7 @@ const InfoPane = () => {
         pane.title = formatters.shipName(lot.surfaceShip);
         pane.subtitle = getShipSubtitle(lot.surfaceShip, surfaceShipReady, { asteroid, lot });
         pane.captainCard = lot.surfaceShip.Control?.controller?.id;
-        pane.hoverSubtitle = 'Zoom to Lot';
+        pane.hoverSubtitle = 'Open Lot Info';
         pane.thumbVisible = true;
         pane.thumbnail = <ThumbBackground image={thumbUrl} />;
       } else if (lotId && lot) {
@@ -521,7 +521,7 @@ const InfoPane = () => {
 
         pane.subtitle = <>{formatters.asteroidName(asteroid)} &gt; <b>{formatters.lotName(lotId)}</b></>;
         pane.captainCard = lot.building?.Control?.controller?.id || explicitLotControllerId;
-        pane.hoverSubtitle = 'Zoom to Lot';
+        pane.hoverSubtitle = 'Open Lot Info';
 
         const assetType = lot?.building ? Building.TYPES[lot.building?.Building?.buildingType]?.name : undefined;
 

--- a/src/game/interface/hud/hudMenus/LotInfo.js
+++ b/src/game/interface/hud/hudMenus/LotInfo.js
@@ -3,18 +3,16 @@ import ResourceRequirement from '~/components/ResourceRequirement';
 import { getBuildingRequirements } from '../actionDialogs/components';
 import useDeliveryManager from '~/hooks/actionManagers/useDeliveryManager';
 
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import styled from 'styled-components';
 import { Building, Ship, Product } from '@influenceth/sdk';
 import moment from 'moment';
 
 import useStore from '~/hooks/useStore';
-import { MagnifyingIcon, TransferToSiteIcon } from '~/components/Icons';
 import useLot from '~/hooks/useLot';
-import Button from '~/components/ButtonAlt';
 import { reactBool, reactPreline } from '~/lib/utils';
 import CrewIndicator from '~/components/CrewIndicator';
-import { HudMenuCollapsibleSection, Scrollable, Tray } from './components/components';
+import { HudMenuCollapsibleSection, Scrollable } from './components/components';
 import LotTitleArea from './components/LotTitleArea';
 import PolicyPanels from './components/PolicyPanels';
 import useCrew from '~/hooks/useCrew';
@@ -87,25 +85,16 @@ const LotInfo = () => {
   const { data: description, isLoading: isContentLoading } = useIpfsContent(annotation?.ipfs?.hash);
   const { data: controller } = useCrew(lot?.building?.Control?.controller?.id);
 
-  const dispatchZoomScene = useStore(s => s.dispatchZoomScene);
-  const zoomScene = useStore(s => s.asteroids.zoomScene);
-
   const gracePeriodPretty = useMemo(() => {
     return moment(Date.now() - Building.GRACE_PERIOD * 1e3).fromNow(true)
   }, []);
-
-  const isZoomedToLot = zoomScene?.type === 'LOT';
-
-  const toggleZoomScene = useCallback(() => {
-    dispatchZoomScene(isZoomedToLot ? null : { type: 'LOT', lotId: lot?.id });
-  }, [isZoomedToLot, lot?.id]);
 
   const siteOrBuilding = (lot?.building?.Building?.status === Building.CONSTRUCTION_STATUSES.OPERATIONAL ? 'Building' : 'Site');
 
   if (!lot || isAnnotationLoading || isContentLoading) return null;
   return (
     <>
-      <Scrollable hasTray={reactBool(!isZoomedToLot)}>
+      <Scrollable hasTray={reactBool(false)}>
         <LotTitleArea lot={lot} />
 
         {description && (
@@ -166,13 +155,6 @@ const LotInfo = () => {
 
       </Scrollable>
     
-      {!isZoomedToLot && (
-        <Tray>
-          <Button onClick={toggleZoomScene}>
-            <MagnifyingIcon style={{ marginRight: 8 }} /> Zoom to Lot
-          </Button>
-        </Tray>
-      )}
     </>
   );
 };

--- a/src/game/interface/modelViewer/ShipViewer.js
+++ b/src/game/interface/modelViewer/ShipViewer.js
@@ -17,7 +17,7 @@ const ShipViewer = () => {
 
   // Play ship thruster loop
   useEffect(() => {
-    if (zoomScene?.type === 'SHIP') {
+    if (zoomScene?.type === 'SHIP' && !ship?._location?.lotId) {
       const id = setTimeout(() => playSound('ship'));
       setPendingSound(id);
 
@@ -27,7 +27,7 @@ const ShipViewer = () => {
         setPendingSound(null);
       }
     }
-  }, [zoomScene]);
+  }, [zoomScene, ship?._location?.lotId]);
 
   const modelUrl = useMemo(() => {
     return getShipModel(
@@ -36,7 +36,7 @@ const ShipViewer = () => {
     );
   }, [ship?.Ship?.shipType, ship?.Ship?.variant]);
 
-  if (zoomScene?.type !== 'SHIP' || isLoading) return null;
+  if (zoomScene?.type !== 'SHIP' || isLoading || ship?._location?.lotId) return null;
   return (
     <ModelViewer assetType="ship" modelUrl={modelUrl} />
   );


### PR DESCRIPTION
Eliminates the "zoomed" view and no longer shows 3D models of buildings. Surfaces all functionality one layer higher (i.e. when clicking on the lot rather than requiring two clicks and longish load time). Will also save on some bandwidth. Ships are still viewable when in orbit / flying.