### PR TITLE
Display hull id alongside hull type

### DIFF
--- a/src/game/interface/hud/hudMenus/DockDetails.js
+++ b/src/game/interface/hud/hudMenus/DockDetails.js
@@ -128,7 +128,7 @@ const DockDetails = ({ onClose }) => {
                     style={{ width: 100, height: 85 }} />
                   <label style={{ padding: '0 8px', width: 'calc(100% - 100px)' }}>
                     <h3 style={{ fontSize: '17px' }}>{formatters.shipName(ship)}</h3>
-                    <div><b>{Ship.TYPES[ship.Ship.shipType]?.name}</b></div>
+                    <div><b>{`${Ship.TYPES[ship.Ship.shipType]?.name} #${ship.id}`}</b></div>
                     {blockTime >= ship.Ship.readyAt && <Ready>Launch Ready</Ready>}
                   </label>
                 </ThumbnailWithData>

--- a/src/game/interface/hud/hudMenus/components/ShipTitleArea.js
+++ b/src/game/interface/hud/hudMenus/components/ShipTitleArea.js
@@ -32,7 +32,7 @@ const ShipTitleArea = ({ ship }) => {
     <TitleArea
       background={`Ship_${ship?.Ship?.shipType || Ship.IDS.SHUTTLE}`}
       title={formatters.shipName(ship)}
-      subtitle={Ship.TYPES[ship?.Ship?.shipType]?.name}
+      subtitle={`${Ship.TYPES[ship?.Ship?.shipType]?.name} #${ship?.id}`}
       upperLeft={(
         <>
           <LocationIcon />


### PR DESCRIPTION
Discord topic: https://discord.com/channels/814990637178290177/1504356208314814574

Added the ship hull id to be displayed alongside the ship hull type, because this information is currently unavailable in the game despite being important for NFT management.

<img width="486" height="710" alt="image" src="https://github.com/user-attachments/assets/a7649fdb-abc7-4162-9410-1c16c251b2e4" />
