### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,12 +4,14 @@ yarn-error.log
 
 .git
 .gitignore
+.github/
 
 .env
 .env.*
 
 Dockerfile
 .dockerignore
+compose*.yaml
 
 dist
 coverage

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+npm-debug.log
+yarn-error.log
+
+.git
+.gitignore
+
+.env
+.env.*
+
+Dockerfile
+.dockerignore
+
+dist
+coverage

--- a/.github/workflows/docker-prerelease.yaml
+++ b/.github/workflows/docker-prerelease.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/docker-prerelease.yaml
+++ b/.github/workflows/docker-prerelease.yaml
@@ -1,0 +1,61 @@
+name: Build prerelease Docker image
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract short SHA
+        id: vars
+        run: echo "sha_short=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Set image name
+        id: image
+        run: |
+          IMAGE=$(echo "ghcr.io/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "image_name=$IMAGE" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .		  
+          file: Dockerfile
+          target: production
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ steps.image.outputs.image_name }}:${{ steps.vars.outputs.sha_short }}
+            ${{ steps.image.outputs.image_name }}:prerelease
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Trigger deployment webhook
+        run: |
+          curl -X POST \
+            -H "X-Webhook-Token: ${{ secrets.PRERELEASE_WEBHOOK_TOKEN }}" \
+            https://api-prerelease.influenceth.io/hooks/refresh-prerelease-client

--- a/.github/workflows/docker-production.yaml
+++ b/.github/workflows/docker-production.yaml
@@ -1,0 +1,46 @@
+name: Promote prerelease to production
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image name
+        id: image
+        run: |
+          IMAGE=$(echo "ghcr.io/${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "image_name=$IMAGE" >> $GITHUB_OUTPUT
+
+      - name: Promote prerelease to latest + production
+        run: |
+          IMAGE=${{ steps.image.outputs.image_name }}
+
+          echo "Promoting $IMAGE:prerelease"
+
+          # Inspect the digest of prerelease
+          DIGEST=$(docker buildx imagetools inspect $IMAGE:prerelease --format '{{.Manifest.Digest}}')
+
+          echo "Found digest: $DIGEST"
+
+          # Retag same digest as latest and production
+          docker buildx imagetools create \
+            -t $IMAGE:latest \
+            -t $IMAGE:production \
+            $IMAGE@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,9 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-# Copy built app; we could probably copy a lot less in search for optimisation - to be researched
-COPY --from=builder /app ./
+# Copy built app
+COPY --from=builder /app/build ./build
+COPY --from=builder /app/server.built.js ./
 
 # Copy runtime injection starting scripts
 COPY --chmod=755 runtime-injection.sh /usr/local/bin/runtime-injection.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# syntax=docker/dockerfile:1
+
+########################################
+# Base dependencies stage
+########################################
+FROM node:20-alpine AS base
+
+WORKDIR /app
+
+COPY package*.json ./
+COPY .npmrc ./
+COPY .nvmrc ./
+COPY .babelrc ./
+COPY .slug-post-clean ./
+
+# Copy patches
+COPY patches ./patches
+
+RUN npm ci
+
+########################################
+# Development stage
+########################################
+FROM base AS development
+
+ENV NODE_ENV=development
+
+# Copy full source
+COPY . .
+
+# Copy runtime injection starting scripts
+COPY --chmod=755 runtime-injection.sh /usr/local/bin/runtime-injection.sh
+COPY --chmod=755 start-dev.sh /usr/local/bin/start-dev.sh
+
+EXPOSE 3000
+
+ENTRYPOINT ["/usr/local/bin/start-dev.sh"]
+
+########################################
+# Build stage
+########################################
+FROM base AS builder
+
+ENV NODE_ENV=production
+
+COPY . .
+
+RUN npm run build
+
+########################################
+# Production runtime stage
+########################################
+FROM node:20-alpine AS production
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+# Copy built app; we could probably copy a lot less in search for optimisation - to be researched
+COPY --from=builder /app ./
+
+# Copy runtime injection starting scripts
+COPY --chmod=755 runtime-injection.sh /usr/local/bin/runtime-injection.sh
+COPY --chmod=755 start-prod.sh /usr/local/bin/start-prod.sh
+
+EXPOSE 3000
+
+ENTRYPOINT ["/usr/local/bin/start-prod.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ########################################
 # Base dependencies stage
 ########################################
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 
 WORKDIR /app
 
@@ -50,7 +50,7 @@ RUN npm run build
 ########################################
 # Production runtime stage
 ########################################
-FROM node:20-alpine AS production
+FROM node:22-alpine AS production
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ you can do so in your local env file by following the instructions in `src/appCo
 
 In the project directory, you can run:
 
+### `runtime-injection.sh`
+
+The app uses runtime configuration injection. Run this script to copy the relevant values from your environment to a `config.js` file read at runtime. This is needed before starting the app.
+
 ### `npm start`
 
 Runs the app in the development mode.\
@@ -82,3 +86,19 @@ If you aren’t satisfied with the build tool and configuration choices, you can
 Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
 
 You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+
+## Running as a Docker container 🐋
+Notes:
+- The `compose.yaml` file in the project expects a Docker network named `web` for the communication across containers (e.g. a Caddy container as reverse proxy). To create it, run `docker network create web` .
+- By default the application port (3000) is only exposed to the `web` Docker network and not to the host machine. Un-comment the port configuration in the various `compose.yaml` files if needed.
+
+### Build and run a development image
+1. Download source
+2. Initialize your `.env` file - `NODE_ENV=development`
+3. Build the image from local source: `docker compose build`
+4. Start the container: `docker compose up`
+
+### Run an official prerelease or production image
+1. Download `compose.prerelease.yaml` or `compose.prod.yaml`
+2. Initialize your `.env` file - `NODE_ENV=production`
+3. Start the container: `docker compose -f compose.prerelease.yaml up` or `docker compose -f compose.prod.yaml up`

--- a/compose.prerelease.yaml
+++ b/compose.prerelease.yaml
@@ -1,0 +1,16 @@
+services:
+  influence-client:
+    image: ghcr.io/adaliafoundation/influence-client:prerelease
+    container_name: influence-client
+    restart: unless-stopped
+    #ports:
+      #- 3000:3000    # main client port    # no binding needed, only docker access
+    networks:
+      - web
+    env_file:
+      - ./.env
+    # no command or entrypoint, use image entrypoint
+
+networks:
+  web:
+    external: true    # we create it with Caddy reverse-proxy container

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,16 @@
+services:
+  influence-client:
+    image: ghcr.io/adaliafoundation/influence-client:production
+    container_name: influence-client
+    restart: unless-stopped
+    #ports:
+      #- 3000:3000    # main client port    # no binding needed, only docker access
+    networks:
+      - web
+    env_file:
+      - ./.env
+    # no command or entrypoint, use image entrypoint
+
+networks:
+  web:
+    external: true    # we create it with Caddy reverse-proxy container

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,21 @@
+services:
+  influence-client:
+    build:    # build the app
+      context: .
+      target: development
+    container_name: influence-client
+    restart: unless-stopped
+    #ports:
+      #- 3000:3000    # main client port    # no binding needed, only docker access
+    networks:
+      - web
+    env_file:
+      - ./.env
+    volumes:
+      - .:/app    # mount the project inside container for live edits
+      - /app/node_modules    # do not overwrite built node dependencies
+    # no command or entrypoint, use image entrypoint
+
+networks:
+  web:
+    external: true    # we create it with Caddy reverse-proxy container

--- a/public/config.js
+++ b/public/config.js
@@ -1,0 +1,10 @@
+window.APP_CONFIG = {
+/*
+
+This file is made to be overwritten automatically before starting the app and contain all REACT_APP variables read from environment
+The goal is to support runtime injection of the config. A react app normally reads environment variable on build/compile time and
+hardcodes the values in the built application, which is incompatible with the idea of building a single Docker image and reusing it
+in multiple environments. Runtime config injection solves this.
+
+*/
+};

--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,10 @@
       when a crawler's user-agent is detected by the server
     -->
     <meta name="opengraph" />
+    <!--
+      Runtime config injection
+    -->
+    <script src="%PUBLIC_URL%/config.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/runtime-injection.sh
+++ b/runtime-injection.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+echo "Generating runtime configuration..."
+
+MODE="${1:-dev}"
+
+if [ "$MODE" = "prod" ]; then
+    CONFIG_FILE="/app/build/config.js"
+else
+    CONFIG_FILE="/app/public/config.js"
+fi
+
+echo "window.APP_CONFIG = {" > "$CONFIG_FILE"
+
+# Export all REACT_APP_* variables automatically
+env | grep '^REACT_APP_' | while IFS='=' read -r key value
+do
+  # escape quotes (minimal safe handling)
+  value=$(printf '%s' "$value" | sed 's/"/\\"/g')
+
+  echo "  $key: \"$value\"," >> "$CONFIG_FILE"
+  
+  echo "  $key: \"$value\","
+done
+
+echo "};" >> "$CONFIG_FILE"
+
+echo "Runtime configuration generated."

--- a/src/appConfig/index.js
+++ b/src/appConfig/index.js
@@ -22,8 +22,13 @@ function flattenObject(obj, parentKey = '', result = {}) {
   }, result);
 }
 
+const runtimeConfig =
+  typeof window !== 'undefined'
+    ? (window.APP_CONFIG || {})
+    : process.env;
+
 // override default config with environment specific config
-const configSelection = process.env.REACT_APP_CONFIG_ENV || process.env.NODE_ENV;
+const configSelection = runtimeConfig.REACT_APP_CONFIG_ENV || process.env.NODE_ENV;
 const rawConfig = {
   ...flattenObject(defaultConfig),
   ...flattenObject(configSelection === 'production' ? productionConfig : prereleaseConfig),
@@ -34,8 +39,8 @@ const appConfigData = reduce(
   rawConfig,
   (res, v, key) => {
     const overrideKey = `REACT_APP_${key.replace(/\./g, '_').toUpperCase()}`;
-    if (process.env.hasOwnProperty(overrideKey)) {
-      res[key] = process.env[overrideKey];
+    if (runtimeConfig.hasOwnProperty(overrideKey)) {
+      res[key] = runtimeConfig[overrideKey];
     }
     return res;
   },

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+/usr/local/bin/runtime-injection.sh dev
+exec npm start

--- a/start-prod.sh
+++ b/start-prod.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+/usr/local/bin/runtime-injection.sh prod
+exec node server.built.js


### PR DESCRIPTION
The goal of the changes is to migrate towards a clean containerized infrastructure. They add support for:

- building Docker images in two flavours:
  - development: watches for changes in the local source files to update the running application
  - production: fully built and minimized application suitable for prerelease (testing) and productive environments

- runtime configuration injection: this is needed in order to be able to run the same image on prerelease and production without the need for a rebuild, ensuring the exact same code runs when promoting a version; this comes with the requirement of running an additional script before starting the application if started manually (this is fully automated if running as a docker image)

- Github actions:
  - build the image (tagged `prerelease`) on a merge to `main`, publishes the image to Github container repository, and triggers a refresh of the prerelease environment to use the new image
  - a manual action to retag the `prerelease` image as `production` and `latest`, preparing for a deployment to production

The application can still be built and run outside of a container environment, but requires running the additional `runtime-injection.sh` script first to copy the environment variables to the runtime configuration file.